### PR TITLE
fix: tailwindcss plugin import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { IconifyJSON } from "@iconify/types"
-import plugin from "tailwindcss/plugin"
+import plugin from "tailwindcss/plugin.js"
 import { generateComponent, getIconCollections } from "./core"
 
 export { getIconCollections }


### PR DESCRIPTION
Trying to fix this error:

Cannot find module '.../ui/node_modules/tailwindcss/plugin' imported from .../ui/node_modules/@egoist/tailwindcss-icons/dist/index.mjs
Did you mean to import tailwindcss/plugin.js?