### PR TITLE
feat: add collection aliases functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Search the icon you want to use here: https://icones.js.org
 | strokeWidth          | number                            | `undefined` | Stroke width for icons (this may not work for all icons) |
 | extraProperties      | Record<string, string>            | `{}`        | Extra CSS properties applied to the generated CSS.       |
 | collectionNamesAlias | [key in CollectionNames]?: string | `{}`        | Alias to customize collection names.                     |
+| collectionAliases    | Record<string, CollectionAlias>   | `{}`        | Alias for whole collections to customize all it's icons. |
 
 ### Custom Icons
 

--- a/example/index.html
+++ b/example/index.html
@@ -11,5 +11,6 @@
     <div class="i-lucide-home"></div>
     <div class="i-tabler-123"></div>
     <div class="i-[mdi--ab-testing]"></div>
+    <div class="i-mdistroke-academic-cap"></div>
   </body>
 </html>

--- a/example/tailwind.config.cjs
+++ b/example/tailwind.config.cjs
@@ -10,7 +10,13 @@ module.exports = {
     iconsPlugin({
       scale: 10,
       strokeWidth: 1,
-      collections: getIconCollections(["lucide", "tabler"]),
+      collections: getIconCollections(["lucide", "tabler", "mdi"]),
+      collectionAliases: {
+        mdistroke: {
+          collection: "mdi",
+          strokeWidth: 2.5,
+        },
+      },
     }),
     dynamicIconsPlugin({ scale: 10 }),
   ],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -432,3 +432,132 @@ test("get all icon explicitly", async () => {
     }"
   `)
 })
+
+test("test collection alias", async () => {
+  const result = await postcss([
+    tailwindcss({
+      config: {
+        content: [
+          {
+            raw: '<span class="i-mdistroke-archive-box"></span>',
+            extension: "html",
+          },
+        ],
+        plugins: [
+          iconsPlugin({
+            collections: getIconCollections(["mdi"]),
+            collectionAliases: {
+              mdistroke: {
+                collection: "mdi",
+                strokeWidth: 2,
+              },
+            },
+          }),
+        ],
+      },
+    }),
+  ]).process(`@tailwind components;
+.foo {
+  @apply i-mdi-home;
+}`)
+
+  expect(result.css).toMatchInlineSnapshot(`
+    ".i-mdistroke-archive-box {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        background-color: currentColor;
+        -webkit-mask-image: var(--svg);
+        mask-image: var(--svg);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125'/%3E%3C/svg%3E")
+    }
+    .foo {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        background-color: currentColor;
+        -webkit-mask-image: var(--svg);
+        mask-image: var(--svg);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='black' d='M10 20v-6h4v6h5v-8h3L12 3L2 12h3v8z'/%3E%3C/svg%3E")
+    }"
+  `)
+})
+
+test("test normal and collection alias", async () => {
+  const result = await postcss([
+    tailwindcss({
+      config: {
+        content: [
+          {
+            raw: '<span class="i-mdistroke-archive-box"></span> <span class="i-mdi-archive-box"></span>',
+            extension: "html",
+          },
+        ],
+        plugins: [
+          iconsPlugin({
+            collections: getIconCollections(["mdi"]),
+            collectionAliases: {
+              mdistroke: {
+                collection: "mdi",
+                strokeWidth: 2,
+              },
+            },
+          }),
+        ],
+      },
+    }),
+  ]).process(`@tailwind components;
+.foo {
+  @apply i-mdi-home;
+}`)
+
+  expect(result.css).toMatchInlineSnapshot(`
+    ".i-mdi-archive-box {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        background-color: currentColor;
+        -webkit-mask-image: var(--svg);
+        mask-image: var(--svg);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125'/%3E%3C/svg%3E")
+    }
+    .i-mdistroke-archive-box {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        background-color: currentColor;
+        -webkit-mask-image: var(--svg);
+        mask-image: var(--svg);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='none' stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='m20.25 7.5l-.625 10.632a2.25 2.25 0 0 1-2.247 2.118H6.622a2.25 2.25 0 0 1-2.247-2.118L3.75 7.5M10 11.25h4M3.375 7.5h17.25c.621 0 1.125-.504 1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125'/%3E%3C/svg%3E")
+    }
+    .foo {
+        display: inline-block;
+        width: 1em;
+        height: 1em;
+        background-color: currentColor;
+        -webkit-mask-image: var(--svg);
+        mask-image: var(--svg);
+        -webkit-mask-repeat: no-repeat;
+        mask-repeat: no-repeat;
+        -webkit-mask-size: 100% 100%;
+        mask-size: 100% 100%;
+        --svg: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath fill='black' d='M10 20v-6h4v6h5v-8h3L12 3L2 12h3v8z'/%3E%3C/svg%3E")
+    }"
+  `)
+})


### PR DESCRIPTION
This allows whole collections to be aliased with per alias `extraProperties`.

Resolves #42

***

I have removed the `bg-white` from one of the example icons as with dark reader/mode addons off, it wouldn't appear for me due to the color overlapping :-D I can remove this change, just let me know